### PR TITLE
Fix reversed Rz sign convention in RotationZ, CRZ, and ParametricRotationZ matrices

### DIFF
--- a/core/src/gate/functions.rs
+++ b/core/src/gate/functions.rs
@@ -220,6 +220,10 @@ pub mod single {
         impl_clone_gate!();
     }
     /// Rotation around Z-axis
+    ///
+    /// Rz(θ) = exp(-i * θ/2 * Z) = diag(e^{-iθ/2}, e^{+iθ/2}),
+    /// following the OpenQASM 3 / `stdgates.inc` convention (same sign as
+    /// RotationX, RotationY, RZZ, and RZX in this module).
     #[derive(Debug, Clone, Copy)]
     pub struct RotationZ {
         /// Target qubit
@@ -238,13 +242,13 @@ pub mod single {
             true
         }
         fn matrix(&self) -> QuantRS2Result<Vec<Complex64>> {
-            let phase = Complex64::new(0.0, -self.theta / 2.0).exp();
-            let phase_conj = Complex64::new(0.0, self.theta / 2.0).exp();
+            let phase_neg = Complex64::new(0.0, -self.theta / 2.0).exp();
+            let phase_pos = Complex64::new(0.0, self.theta / 2.0).exp();
             Ok(vec![
-                phase_conj,
+                phase_neg,
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
-                phase,
+                phase_pos,
             ])
         }
         fn as_any(&self) -> &dyn Any {
@@ -935,8 +939,8 @@ pub mod multi {
             true
         }
         fn matrix(&self) -> QuantRS2Result<Vec<Complex64>> {
-            let phase = Complex64::new(0.0, -self.theta / 2.0).exp();
-            let phase_conj = Complex64::new(0.0, self.theta / 2.0).exp();
+            let phase_neg = Complex64::new(0.0, -self.theta / 2.0).exp();
+            let phase_pos = Complex64::new(0.0, self.theta / 2.0).exp();
             Ok(vec![
                 Complex64::new(1.0, 0.0),
                 Complex64::new(0.0, 0.0),
@@ -948,12 +952,12 @@ pub mod multi {
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
-                phase_conj,
+                phase_neg,
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
                 Complex64::new(0.0, 0.0),
-                phase,
+                phase_pos,
             ])
         }
         fn as_any(&self) -> &dyn Any {

--- a/core/src/parametric.rs
+++ b/core/src/parametric.rs
@@ -740,13 +740,13 @@ impl GateOp for ParametricRotationZ {
                 ))
             },
             |theta| {
-                let phase = Complex64::new(0.0, -theta / 2.0).exp();
-                let phase_conj = Complex64::new(0.0, theta / 2.0).exp();
+                let phase_neg = Complex64::new(0.0, -theta / 2.0).exp();
+                let phase_pos = Complex64::new(0.0, theta / 2.0).exp();
                 Ok(vec![
-                    phase_conj,
+                    phase_neg,
                     Complex64::new(0.0, 0.0),
                     Complex64::new(0.0, 0.0),
-                    phase,
+                    phase_pos,
                 ])
             },
         )

--- a/core/tests/gate_convention_tests.rs
+++ b/core/tests/gate_convention_tests.rs
@@ -1,0 +1,102 @@
+//! Regression tests for the Rz-family sign convention.
+//!
+//! Rz(θ) must equal exp(-i * θ/2 * Z) = diag(e^{-iθ/2}, e^{+iθ/2}), matching
+//! the OpenQASM 3 `stdgates.inc` / Qiskit convention, this crate's own
+//! RotationX/RotationY/RZZ/RZX sign, and the specialized RZ paths in
+//! `quantrs2-sim` (`RZSpecialized`, adaptive gate fusion, circuit interfaces).
+//!
+//! These tests are deliberately phase-sensitive: magnitude-only assertions
+//! are satisfied by any diagonal unitary and cannot detect a reversed sign.
+//! See <https://github.com/cool-japan/quantrs/issues/32>.
+
+use quantrs2_core::gate::multi::CRZ;
+use quantrs2_core::gate::single::{Phase, RotationZ};
+use quantrs2_core::gate::GateOp;
+use quantrs2_core::parametric::ParametricRotationZ;
+use quantrs2_core::qubit::QubitId;
+use std::f64::consts::{FRAC_PI_2, FRAC_PI_4};
+
+const EPS: f64 = 1e-12;
+
+fn assert_entry(re: f64, im: f64, expected_re: f64, expected_im: f64, what: &str) {
+    assert!(
+        (re - expected_re).abs() < EPS && (im - expected_im).abs() < EPS,
+        "{what}: got {re}{im:+}i, expected {expected_re}{expected_im:+}i"
+    );
+}
+
+#[test]
+fn rotation_z_matches_openqasm3_standard() {
+    let rz = RotationZ {
+        target: QubitId(0),
+        theta: FRAC_PI_2,
+    };
+    let m = rz.matrix().expect("RZ matrix should be available");
+    let c = FRAC_PI_4.cos();
+    // Rz(π/2) = diag(e^{-iπ/4}, e^{+iπ/4})
+    assert_entry(m[0].re, m[0].im, c, -c, "Rz(π/2)[0][0]");
+    assert_entry(m[3].re, m[3].im, c, c, "Rz(π/2)[1][1]");
+    assert_entry(m[1].re, m[1].im, 0.0, 0.0, "Rz(π/2)[0][1]");
+    assert_entry(m[2].re, m[2].im, 0.0, 0.0, "Rz(π/2)[1][0]");
+}
+
+#[test]
+fn rotation_z_half_pi_is_s_up_to_global_phase() {
+    // Within this gate set, Rz(π/2) must equal the S gate up to global phase
+    // (their diagonal ratios m11/m00 must both be +i).
+    let rz = RotationZ {
+        target: QubitId(0),
+        theta: FRAC_PI_2,
+    };
+    let s = Phase { target: QubitId(0) };
+    let m = rz.matrix().expect("RZ matrix should be available");
+    let ms = s.matrix().expect("S matrix should be available");
+    let ratio = m[3] / m[0];
+    let s_ratio = ms[3] / ms[0];
+    assert_entry(
+        ratio.re,
+        ratio.im,
+        s_ratio.re,
+        s_ratio.im,
+        "Rz(π/2) diagonal ratio vs S",
+    );
+    assert_entry(ratio.re, ratio.im, 0.0, 1.0, "Rz(π/2) diagonal ratio");
+}
+
+#[test]
+fn parametric_rotation_z_matches_gate_rotation_z() {
+    let theta = 0.7312;
+    let gate = RotationZ {
+        target: QubitId(0),
+        theta,
+    };
+    let par = ParametricRotationZ::new(QubitId(0), theta);
+    let mg = gate.matrix().expect("RZ matrix should be available");
+    let mp = par
+        .matrix()
+        .expect("parametric RZ matrix should be available");
+    for (i, (a, b)) in mg.iter().zip(mp.iter()).enumerate() {
+        assert_entry(
+            a.re,
+            a.im,
+            b.re,
+            b.im,
+            &format!("RotationZ vs ParametricRotationZ entry {i}"),
+        );
+    }
+}
+
+#[test]
+fn crz_target_block_matches_openqasm3_standard() {
+    let crz = CRZ {
+        control: QubitId(0),
+        target: QubitId(1),
+        theta: FRAC_PI_2,
+    };
+    let m = crz.matrix().expect("CRZ matrix should be available");
+    let c = FRAC_PI_4.cos();
+    // The control=|1⟩ block applies Rz(π/2) = diag(e^{-iπ/4}, e^{+iπ/4});
+    // in the row-major 4x4 layout these are entries [10] and [15].
+    assert_entry(m[10].re, m[10].im, c, -c, "CRZ(π/2)[2][2]");
+    assert_entry(m[15].re, m[15].im, c, c, "CRZ(π/2)[3][3]");
+}


### PR DESCRIPTION
## Summary

Fixes #32.

`GateOp::matrix()` for `RotationZ`, `CRZ`, and `ParametricRotationZ` returned `diag(e^{+iθ/2}, e^{-iθ/2})` — the negation of `Rz(θ) = exp(-i θ/2 Z)` as defined by OpenQASM 3 `stdgates.inc` and implemented by Qiskit-compatible tooling. This PR swaps the two diagonal entries at those three sites, documents the convention on `RotationZ`, and adds phase-sensitive regression tests.

## Why the fix goes in this direction

Every other Rz implementation in this repository already uses the standard sign; the three fixed sites were the outliers:

| Site | Convention (before this PR) |
|---|---|
| `RotationX` / `RotationY` (`core/src/gate/functions.rs`) | standard `exp(-iθσ/2)` |
| `RZZ` / `RZX` code and doc comments (`core/src/gate/functions.rs`) | standard |
| `RZSpecialized` ([`sim/src/specialized_gates.rs#L446-L447`](https://github.com/cool-japan/quantrs/blob/e0856c76ec2e86abb78f0dd7ccafe8c1e1fd56f2/sim/src/specialized_gates.rs#L446-L447)) | standard |
| Adaptive gate fusion (`sim/src/adaptive_gate_fusion/types.rs#L1149-L1160`) | standard |
| Circuit interfaces (`sim/src/circuit_interfaces/types.rs#L977-L987`) | standard |
| `neutral_atom::rz_gate` (`core/src/neutral_atom.rs#L739-L746`) | standard |
| `silicon_quantum_dots` Z-rotation (`core/src/silicon_quantum_dots.rs#L454-L455`) | standard |
| **`RotationZ::matrix()`** | **reversed** |
| **`CRZ::matrix()`** | **reversed** |
| **`ParametricRotationZ::matrix()`** | **reversed** |

Concrete consequences of the old state:

1. **The simulator disagreed with itself.** `quantrs2-sim` swaps `RotationZ` for `RZSpecialized` when specialization is enabled ([`specialized_gates.rs#L856-L861`](https://github.com/cool-japan/quantrs/blob/e0856c76ec2e86abb78f0dd7ccafe8c1e1fd56f2/sim/src/specialized_gates.rs#L856-L861)), which applies the *standard* sign — while any path going through `GateOp::matrix()` applied the reverse. The same circuit could produce different states depending on dispatch.
2. **Internal gate-set inconsistency.** `Rz(π/2)` was phase-equivalent to `S†` rather than `S`, although this crate's `Phase`/S gate is the standard `diag(1, i)`.
3. **Silent QASM interop corruption.** The exporter maps `"RZ" => "rz"` one-to-one (`circuit/src/qasm/export.rs#L32`) and the importer maps `rz` back without negation, so exported circuits were wrong for any `stdgates.inc`-conformant consumer. Runtime demonstration against the published `quantrs2-core` v0.2.0: https://github.com/cool-japan/quantrs/issues/32#issuecomment-4997511096

## Changes

- `core/src/gate/functions.rs` — swap the diagonal entries in `RotationZ::matrix()` and `CRZ::matrix()`; document the convention in the `RotationZ` doc comment.
- `core/src/parametric.rs` — the same swap in `ParametricRotationZ`'s matrix closure.
- `core/tests/gate_convention_tests.rs` (new) — four phase-sensitive regression tests: `Rz(π/2)` matrix values, `Rz(π/2) ∝ S` (diagonal-ratio check), `ParametricRotationZ == RotationZ`, and the `CRZ` control block. These deliberately assert complex amplitudes: the pre-existing `test_rz_gate` (`core/src/simd_enhanced.rs`) asserts only magnitudes, which any diagonal unitary satisfies — which is why the reversal was invisible to the existing suite.

## Test plan

- `cargo test -p quantrs2-core --test gate_convention_tests` → **4 passed**
- `cargo test -p quantrs2-core --lib` → **962 passed; 0 failed; 7 ignored**

The clean full-suite run also confirms nothing inside the workspace compensated for the reversed sign (no angle negations at `RotationZ` call sites were found by inspection either).

## Compatibility note

Downstream code that pre-negated angles to compensate would need to stop doing so; within this repository no such compensation exists. After this change, `Rz`-dependent results match what Qiskit/OpenQASM-conformant tools produce for the same circuit, and `GateOp::matrix()` agrees with `quantrs2-sim`'s specialized path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
